### PR TITLE
No event.user object causes error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ let config = null
 
 const incomingMiddleware = (event, next) => {
   if (!db) { return next() }
+  
+  if(!event.user) { return next()}
 
   if (_.includes(['delivery', 'read'], event.type)) {
     return next()


### PR DESCRIPTION
Skip getting user session from HITL table if no user object on event.

When using modules like Webhook that does not attach a user object to the event object causes an error in incomingMiddlewares. HITL tries to create new session but throws an error as user.id is undefined in knex db create.